### PR TITLE
Suppression d'un compte avec validation + refacto léger + légers changement css/html

### DIFF
--- a/src/main/java/fr/eni/tp/encheres/bll/UserService.java
+++ b/src/main/java/fr/eni/tp/encheres/bll/UserService.java
@@ -37,8 +37,9 @@ public interface UserService {
 	 * Delete account.
 	 *
 	 * @param userId the user id
+	 * @throws BusinessException 
 	 */
-	void deleteAccount(int userId);
+	void deleteAccount(int userId) throws BusinessException;
 	
 	/**
 	 * View own points.

--- a/src/main/java/fr/eni/tp/encheres/controller/BidController.java
+++ b/src/main/java/fr/eni/tp/encheres/controller/BidController.java
@@ -15,6 +15,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import fr.eni.tp.encheres.bll.AuctionService;
 import fr.eni.tp.encheres.bll.UserService;
 import fr.eni.tp.encheres.bo.Article;
+import fr.eni.tp.encheres.bo.ArticleState;
 import fr.eni.tp.encheres.bo.User;
 import fr.eni.tp.encheres.exception.BusinessException;
 
@@ -38,18 +39,18 @@ public class BidController {
 									Model model) {
 		Article articleToDisplay = auctionService.findArticleById(articleId);
 		System.out.println(articleToDisplay);
-		// Check si on peut enchérir
-		// càd la date actuelle est entre la date de début et la date de fin de l'enchère.
-		boolean isBidPossible = (LocalDateTime.now().isAfter(articleToDisplay.getAuctionStartDate()) 
-								&& LocalDateTime.now().isBefore(articleToDisplay.getAuctionEndDate()));
 		
-		// Changement de l'enchère/article possible (modification/annulation)
-		// si la date actuelle est avant le début ou pendant l'enchère
-		boolean isBeforeStart = LocalDateTime.now().isBefore(articleToDisplay.getAuctionStartDate());
+		
+		boolean isBidPossible = articleToDisplay.getState().equals(ArticleState.STARTED);
+		boolean isBeforeStart = articleToDisplay.getState().equals(ArticleState.NOT_STARTED);
+		
 		boolean isChangePossible = isBeforeStart || isBidPossible;
 		
+		boolean isAuctionCanceled = articleToDisplay.getState().equals(ArticleState.CANCELED);
 		
-		boolean isAuctionFinished = LocalDateTime.now().isAfter(articleToDisplay.getAuctionEndDate());
+		boolean isAuctionFinished = articleToDisplay.getState().equals(ArticleState.FINISHED)
+				|| articleToDisplay.getState().equals(ArticleState.RETRIEVED);
+		
 		
 		model.addAttribute("articleDisplay", articleToDisplay);
 		model.addAttribute("userSession", userSession);
@@ -59,6 +60,7 @@ public class BidController {
 		model.addAttribute("isBidPossible", isBidPossible);
 		model.addAttribute("isBeforeStart", isBeforeStart);
 		model.addAttribute("isAuctionFinished", isAuctionFinished);
+		model.addAttribute("isAuctionCanceled", isAuctionCanceled);
 		
 		
 		// Ajout de la date au bon format !

--- a/src/main/java/fr/eni/tp/encheres/controller/ProfilController.java
+++ b/src/main/java/fr/eni/tp/encheres/controller/ProfilController.java
@@ -76,4 +76,24 @@ public class ProfilController {
 			}
 		}
 	}
+	
+	
+	@GetMapping("/deleteAccount")
+	public String deleteUserAccount(@SessionAttribute("userSession") User userSession, @RequestParam(name="userId") int userId) {
+		
+		//check si c'est bien l'utilisateur connecté qui veut supprimer
+		if(userSession.getUserId()!=userId) {
+			System.err.println("Pas le bon utilisateur !");
+			return "redirect:/auctions";
+		}
+		
+		
+		userService.deleteAccount(userId);
+		
+	
+		
+		return "redirect:/auctions";
+	}
+	
+	
 }

--- a/src/main/java/fr/eni/tp/encheres/controller/ProfilController.java
+++ b/src/main/java/fr/eni/tp/encheres/controller/ProfilController.java
@@ -92,7 +92,7 @@ public class ProfilController {
 		
 	
 		
-		return "redirect:/auctions";
+		return "redirect:/logout";
 	}
 	
 	

--- a/src/main/java/fr/eni/tp/encheres/controller/ProfilController.java
+++ b/src/main/java/fr/eni/tp/encheres/controller/ProfilController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.SessionAttribute;
 import org.springframework.web.bind.annotation.SessionAttributes;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import fr.eni.tp.encheres.bll.UserService;
 import fr.eni.tp.encheres.bo.User;
@@ -79,7 +80,7 @@ public class ProfilController {
 	
 	
 	@GetMapping("/deleteAccount")
-	public String deleteUserAccount(@SessionAttribute("userSession") User userSession, @RequestParam(name="userId") int userId) {
+	public String deleteUserAccount(@SessionAttribute("userSession") User userSession, @RequestParam(name="userId") int userId, RedirectAttributes redirectAttributes) {
 		
 		//check si c'est bien l'utilisateur connecté qui veut supprimer
 		if(userSession.getUserId()!=userId) {
@@ -88,11 +89,20 @@ public class ProfilController {
 		}
 		
 		
-		userService.deleteAccount(userId);
+		try {
+			userService.deleteAccount(userId);
+			
+			
+			//Si pas d'erreur, on déconnecte
+			return "redirect:/logout";
+			
+		} catch (BusinessException e) {
+			e.getErreurs().forEach(err -> redirectAttributes.addFlashAttribute("globalError", err));
+			return "redirect:/profil/modify";
+		}
 		
 	
 		
-		return "redirect:/logout";
 	}
 	
 	

--- a/src/main/java/fr/eni/tp/encheres/dal/ArticleDAO.java
+++ b/src/main/java/fr/eni/tp/encheres/dal/ArticleDAO.java
@@ -21,4 +21,6 @@ public interface ArticleDAO {
 	List<Article> findWithFilters(Article article, HashMap<String, Boolean> filters, String buyOrSale, int userId);
 	int countArticlesByBuyerId(int userId);
 	int countArticlesFinishedBySellerId(int userId);
+	void eraserSellerByUserId(int userId);
+	List<Article> findCancellableBySellerId(int userId);
 }

--- a/src/main/java/fr/eni/tp/encheres/dal/ArticleDAO.java
+++ b/src/main/java/fr/eni/tp/encheres/dal/ArticleDAO.java
@@ -19,4 +19,6 @@ public interface ArticleDAO {
 	List<Article> findArticleToUpdateToFinished();
 	List<Article> findArticleToUpdateToStarted();
 	List<Article> findWithFilters(Article article, HashMap<String, Boolean> filters, String buyOrSale, int userId);
+	int countArticlesByBuyerId(int userId);
+	int countArticlesFinishedBySellerId(int userId);
 }

--- a/src/main/java/fr/eni/tp/encheres/dal/ArticleDAOImpl.java
+++ b/src/main/java/fr/eni/tp/encheres/dal/ArticleDAOImpl.java
@@ -35,6 +35,9 @@ public class ArticleDAOImpl implements ArticleDAO{
 	
 	private static final String SCHEDULED_COUNT = "SELECT count(*) FROM ARTICLES_VENDUS WHERE no_article > :idMin";
 	
+	private static final String COUNT_FINISHED_BY_USER_ID = "SELECT count(*) FROM ARTICLES_VENDUS WHERE etat_vente = 3 AND no_utilisateur = :userId";
+	private static final String COUNT_BUYERS_BY_USER_ID = "SELECT count(*) FROM ARTICLES_VENDUS WHERE etat_vente = 2 AND no_acheteur = :userId";
+	
 	
 	private static final String FIND_TO_UPDATE_TO_FINISHED = "SELECT no_article, nom_article, description, date_debut_encheres, date_fin_encheres, prix_initial, prix_vente, no_utilisateur, no_categorie, no_acheteur, etat_vente FROM ARTICLES_VENDUS WHERE date_fin_encheres < GETDATE() AND etat_vente = 2";
 	private static final String FIND_TO_UPDATE_TO_STARTED = "SELECT no_article, nom_article, description, date_debut_encheres, date_fin_encheres, prix_initial, prix_vente, no_utilisateur, no_categorie, no_acheteur, etat_vente FROM ARTICLES_VENDUS WHERE date_debut_encheres < GETDATE() AND etat_vente = 1";
@@ -162,6 +165,26 @@ public class ArticleDAOImpl implements ArticleDAO{
 		return jdbcTemplate.queryForObject(SCHEDULED_COUNT,mapSqlParameterSource, Integer.class);
 	}
 	
+	
+	@Override
+	public int countArticlesFinishedBySellerId(int userId) {
+		MapSqlParameterSource mapSqlParameterSource = new MapSqlParameterSource();
+		mapSqlParameterSource.addValue("userId", userId);
+
+		return jdbcTemplate.queryForObject(COUNT_FINISHED_BY_USER_ID,mapSqlParameterSource, Integer.class);
+	}
+	
+
+	@Override
+	public int countArticlesByBuyerId(int userId) {
+		MapSqlParameterSource mapSqlParameterSource = new MapSqlParameterSource();
+		mapSqlParameterSource.addValue("userId", userId);
+
+		return jdbcTemplate.queryForObject(COUNT_BUYERS_BY_USER_ID,mapSqlParameterSource, Integer.class);
+	}
+	
+	
+	
 	@Override
 	public List<Article> findArticleToUpdateToFinished() {
 		return jdbcTemplate.query(FIND_TO_UPDATE_TO_FINISHED, new ArticleRowMapper());
@@ -171,6 +194,8 @@ public class ArticleDAOImpl implements ArticleDAO{
 	public List<Article> findArticleToUpdateToStarted() {
 		return jdbcTemplate.query(FIND_TO_UPDATE_TO_STARTED, new ArticleRowMapper());
 	}
+	
+	
 	
 	@Override
 	public List<Article> findWithFilters(Article article, HashMap<String, Boolean> filters, String buyOrSale, int userId){

--- a/src/main/java/fr/eni/tp/encheres/dal/ArticleDAOImpl.java
+++ b/src/main/java/fr/eni/tp/encheres/dal/ArticleDAOImpl.java
@@ -23,10 +23,12 @@ import fr.eni.tp.encheres.bo.User;
 public class ArticleDAOImpl implements ArticleDAO{
 	
 	private static final String FIND_BY_ID = "SELECT no_article, nom_article, description, date_debut_encheres, date_fin_encheres, prix_initial, prix_vente, no_utilisateur, no_categorie, no_acheteur, etat_vente FROM ARTICLES_VENDUS WHERE no_article = :articleId";
+	
 	private static final String FIND_ALL = "SELECT no_article, nom_article, description, date_debut_encheres, date_fin_encheres, prix_initial, prix_vente, no_utilisateur, no_categorie, no_acheteur, etat_vente FROM ARTICLES_VENDUS";
 	private static final String FIND_BY_CATEGORY = "SELECT no_article, nom_article, description, date_debut_encheres, date_fin_encheres, prix_initial, prix_vente, no_utilisateur, no_categorie, no_acheteur, etat_vente FROM ARTICLES_VENDUS WHERE no_categorie = :categoryId";
 	private static final String FIND_BY_NAME = "SELECT no_article, nom_article, description, date_debut_encheres, date_fin_encheres, prix_initial, prix_vente, no_utilisateur, no_categorie, no_acheteur, etat_vente FROM ARTICLES_VENDUS WHERE nom_article LIKE :name";
 	private static final String FIND_BY_CATEGORY_AND_NAME = "SELECT no_article, nom_article, description, date_debut_encheres, date_fin_encheres, prix_initial, prix_vente, no_utilisateur, no_categorie, no_acheteur, etat_vente FROM ARTICLES_VENDUS WHERE no_categorie = :categoryId AND nom_article LIKE :name";
+	
 	private static final String INSERT = "INSERT INTO ARTICLES_VENDUS (nom_article, description, date_debut_encheres, date_fin_encheres, prix_initial, prix_vente, no_utilisateur,no_categorie, etat_vente) VALUES (:name, :description, :startDate, :endDate, :startPrice, :endPrice, :userId, :categoryId, :state)";
 	private static final String DELETE = "DELETE FROM ARTICLES_VENDUS WHERE no_article = :articleId";
 	
@@ -37,11 +39,12 @@ public class ArticleDAOImpl implements ArticleDAO{
 	
 	private static final String COUNT_FINISHED_BY_USER_ID = "SELECT count(*) FROM ARTICLES_VENDUS WHERE etat_vente = 3 AND no_utilisateur = :userId";
 	private static final String COUNT_BUYERS_BY_USER_ID = "SELECT count(*) FROM ARTICLES_VENDUS WHERE etat_vente = 2 AND no_acheteur = :userId";
-	
-	
+
 	private static final String FIND_TO_UPDATE_TO_FINISHED = "SELECT no_article, nom_article, description, date_debut_encheres, date_fin_encheres, prix_initial, prix_vente, no_utilisateur, no_categorie, no_acheteur, etat_vente FROM ARTICLES_VENDUS WHERE date_fin_encheres < GETDATE() AND etat_vente = 2";
 	private static final String FIND_TO_UPDATE_TO_STARTED = "SELECT no_article, nom_article, description, date_debut_encheres, date_fin_encheres, prix_initial, prix_vente, no_utilisateur, no_categorie, no_acheteur, etat_vente FROM ARTICLES_VENDUS WHERE date_debut_encheres < GETDATE() AND etat_vente = 1";
 	
+	private static final String FIND_CANCELLABLE_BY_SELLER_ID = "SELECT no_article, nom_article, description, date_debut_encheres, date_fin_encheres, prix_initial, prix_vente, no_utilisateur, no_categorie, no_acheteur, etat_vente FROM ARTICLES_VENDUS WHERE no_utilisateur = :userId AND etat_vente IN (2,3)";
+	private static final String ERASE_BY_USER_ID = "UPDATE ARTICLES_VENDUS SET no_utilisateur = 0 WHERE no_utilisateur = :userId";
 	
 	
 	private NamedParameterJdbcTemplate jdbcTemplate;
@@ -73,6 +76,14 @@ public class ArticleDAOImpl implements ArticleDAO{
 	@Override
 	public List<Article> findAll() {
 		return jdbcTemplate.query(FIND_ALL, new ArticleRowMapper());
+	}
+	
+	@Override
+	public List<Article> findCancellableBySellerId(int userId) {
+		MapSqlParameterSource mapSqlParameterSource = new MapSqlParameterSource();
+		mapSqlParameterSource.addValue("userId", userId);
+		
+		return jdbcTemplate.query(FIND_CANCELLABLE_BY_SELLER_ID, mapSqlParameterSource, new ArticleRowMapper());
 	}
 
 	@Override
@@ -156,6 +167,16 @@ public class ArticleDAOImpl implements ArticleDAO{
 		
 		jdbcTemplate.update(DELETE, mapSqlParameterSource);
 	}
+	
+	@Override
+	public void eraserSellerByUserId(int userId) {
+		MapSqlParameterSource mapSqlParameterSource = new MapSqlParameterSource();
+		mapSqlParameterSource.addValue("userId", userId);
+		
+		jdbcTemplate.update(ERASE_BY_USER_ID, mapSqlParameterSource);
+	}
+	
+	
 	
 	@Override
 	public int countArticles() {

--- a/src/main/java/fr/eni/tp/encheres/dal/ArticleDAOImpl.java
+++ b/src/main/java/fr/eni/tp/encheres/dal/ArticleDAOImpl.java
@@ -223,7 +223,6 @@ public class ArticleDAOImpl implements ArticleDAO{
 		//Récupérer les paramètres de filtre :
 		String textFilter = "%"+article.getArticleName()+"%";
 		int categoryId = article.getCategory().getCategoryId();
-		System.out.println("userIdService : " +userId);
 		// Construire la requête à envoyée en fonction des filtres
 		String SQLQuery = "";
 
@@ -352,8 +351,6 @@ public class ArticleDAOImpl implements ArticleDAO{
 			article.setSeller(seller);
 			
 			
-			//System.err.println("articleDAO : "+ article);
-			//System.out.println("-------------------------");
 			return article;
 		}
 	}

--- a/src/main/java/fr/eni/tp/encheres/dal/AuctionDAO.java
+++ b/src/main/java/fr/eni/tp/encheres/dal/AuctionDAO.java
@@ -16,4 +16,6 @@ public interface AuctionDAO {
 
 
 	void delete(int userId, int articleId, LocalDateTime date);
+
+	void eraseUserBidsByUserId(int userId);
 }

--- a/src/main/java/fr/eni/tp/encheres/dal/AuctionDAOImpl.java
+++ b/src/main/java/fr/eni/tp/encheres/dal/AuctionDAOImpl.java
@@ -23,6 +23,9 @@ public class AuctionDAOImpl implements AuctionDAO {
 	private static final String INSERT = "INSERT INTO ENCHERES (no_utilisateur, no_article, date_enchere, montant_enchere) VALUES (:userId, :articleId, :date, :bidAmount)";
 	private static final String DELETE = "DELETE FROM ENCHERES WHERE no_utilisateur = :userId AND no_article = :articleId AND date_enchere = :auctionDate";
 
+	private static final String ERASE_BY_USER_ID = "UPDATE ENCHERES SET no_utilisateur = 0 WHERE no_utilisateur = :userId";
+	
+	
 	private NamedParameterJdbcTemplate jdbcTemplate;
 
 	public AuctionDAOImpl(NamedParameterJdbcTemplate jdbcTemplate) {
@@ -75,6 +78,15 @@ public class AuctionDAOImpl implements AuctionDAO {
 		mapSqlParameterSource.addValue("auctionDate", auctionDate);
 
 		jdbcTemplate.update(DELETE, mapSqlParameterSource);
+	}
+	
+	
+	@Override
+	public void eraseUserBidsByUserId(int userId) {
+		MapSqlParameterSource mapSqlParameterSource = new MapSqlParameterSource();
+		mapSqlParameterSource.addValue("userId", userId);
+
+		jdbcTemplate.update(ERASE_BY_USER_ID, mapSqlParameterSource);
 	}
 
 }

--- a/src/main/resources/static/css/bid-article-detail.css
+++ b/src/main/resources/static/css/bid-article-detail.css
@@ -135,7 +135,7 @@ button {
 	width:100%;
 	padding:0 20px;
 	display:flex;
-	justify-content:space-between;
+	justify-content:center;
 	
 }
 

--- a/src/main/resources/templates/auctions.html
+++ b/src/main/resources/templates/auctions.html
@@ -91,7 +91,7 @@
 				<h3><a th:href="@{/bid(articleId=${art.articleId})}" th:text="${art.articleName}"></a></h3>
 				<p th:text="#{label.price}+' '+${art.currentPrice}+' points'"></p>
 				<p th:text="#{label.auctionEnd}+' '+${art.auctionEndDate}"></p>
-				<p sec:authorize="!isAuthenticated()" th:text="#{label.seller} '+${art.seller.pseudo}"></p>
+				<p sec:authorize="!isAuthenticated()" th:text="#{label.seller}+' '+${art.seller.pseudo}"></p>
 				<p sec:authorize="isAuthenticated()" th:text="#{label.seller}">
 				<a th:href="@{/profil(userId=${art.seller.userId})}" th:text="${art.seller.pseudo}"></a></p>
 			</div>
@@ -103,6 +103,7 @@
 
 
 <script src="/js/checkbox.js"></script>
+<script src="/js/navbar.js"></script>
 
 </body>
 

--- a/src/main/resources/templates/bid-article-detail.html
+++ b/src/main/resources/templates/bid-article-detail.html
@@ -81,7 +81,6 @@
             
             <div class="modify-auction-container" th:if="${isChangePossible && articleDisplay.seller.userId==userSession.userId}">
             	<a class="button-styled-link" th:href="@{/auctions/modifyArticle(articleId=${articleDisplay.articleId})}" th:text="#{button.modifySale}"></a>
-            	<p class="button-styled-link" th:text="#{button.futureDelete}"></p>
             </div>
             <div th:if="${globalError}" th:text="${globalError}" class="error-message"></div>
         </div>

--- a/src/main/resources/templates/profil-modify.html
+++ b/src/main/resources/templates/profil-modify.html
@@ -83,7 +83,7 @@
 			
 			<div class="buttons-container">
 				<button type="submit" class="button">Enregistrer</button>
-				<a th:href="@{/}" class="button">Supprimer mon compte</a>
+				<a th:href="@{/profil/deleteAccount(userId=${userSession.userId})}" class="button">Supprimer mon compte</a>
 			</div>
 			
 			<div th:replace="~{/fragments/errors/fragment-errors-global::frag-errors}"></div>

--- a/src/main/resources/templates/profil-modify.html
+++ b/src/main/resources/templates/profil-modify.html
@@ -96,6 +96,7 @@
 			<div th:replace="~{/fragments/errors/fragment-error::frag-error(zipCode)}"></div>
 			<div th:replace="~{/fragments/errors/fragment-error::frag-error(city)}"></div>
 		
+			<div th:if="${globalError}" th:text="${globalError}" class="error-message"></div>
 		</form>
 	
 	</main>


### PR DESCRIPTION
**Implémentation de la suppression d'un compte :**
 - création d'un enregistrement générique dans UTILISATEURS (id à 0 et champs vides ou égaux à <utilisateur supprimé>
 - vérification des conditions (pas d'articles vendus mais pas récupérés ET pas le plus gros enchérisseur sur un article)
 - mise à 0 de l'identifiant de cet utilisateur dans chaque enregistrement d'ENCHERES
 - annulation des ventes pas commencées et en cours de cet utilisateur
 - passage des no_utilisateurs des articles de l'utilisateur à 0
 - suppression de l'enregistrement de l'utilisateur en BDD
 - validation et affichage des erreurs coté front
 
 **Petites modifs**
 - enlever le bouton de suppression d'une enchère dans bid-article-detail (il se situ en fait dans article-modify)
 - utilisation de ArticleState dans le controlleur pour l'affichage de conditionnel de "meilleure offre"
 - ajout de navbar.js à auctions
 - changements CSS mineurs